### PR TITLE
Fixed pagination

### DIFF
--- a/Jira.Rest.Sdk/Dtos/Pagination2.cs
+++ b/Jira.Rest.Sdk/Dtos/Pagination2.cs
@@ -25,8 +25,8 @@ namespace Jira.Rest.Sdk.Dtos
         /// <summary>
         /// The URL of the next page of results, if any.
         /// </summary>
-        [JsonProperty("nextPage")]
-        public string NextPage { get; set; }
+        [JsonProperty("nextPageToken")]
+        public string NextPageToken { get; set; }
 
         /// <summary>
         /// The URL of the page.
@@ -63,22 +63,5 @@ namespace Jira.Rest.Sdk.Dtos
         /// </summary>
         public List<T> PaginatedItems => Issues ?? Values;
 
-        /// <summary>
-        /// Gets the next page token extracted from the NextPage URL.
-        /// Returns null if there is no next page or if NextPage is null/empty.
-        /// </summary>
-        public string NextPageToken
-        {
-            get
-            {
-                if (string.IsNullOrEmpty(NextPage))
-                    return null;
-
-                var uri = new System.Uri(NextPage);
-                var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
-                var values = query.GetValues("startAt");
-                return values?.LastOrDefault(); // Take the last value if multiple exist
-            }
-        }
     }
 }

--- a/Jira.Rest.Sdk/Jira.Rest.Sdk.csproj
+++ b/Jira.Rest.Sdk/Jira.Rest.Sdk.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
@@ -32,7 +32,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <ProjectReference Include="..\..\Selenium.Essentials\src\TestAny.Essentials.Api\TestAny.Essentials.Api.csproj" />
+	  <PackageReference Include="Newtonsoft.Json" Version="13.0.5-beta1" />
+	  <PackageReference Include="Pj.Library" Version="1.0.5.3" />
+	  <PackageReference Include="TestAny.Essentials.Api" Version="2.0.5" />
+	  <PackageReference Include="TestAny.Essentials.Core" Version="2.0.5" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Update="product-description.txt">


### PR DESCRIPTION
Hi,

Pagination only uses the NextPageToken, the "NextPage" property is not used anymore in v3. As such the property and the handling for generating a URL is not required (https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-post)